### PR TITLE
Feature/planner parameters

### DIFF
--- a/base/PlannerConfigurator.hpp
+++ b/base/PlannerConfigurator.hpp
@@ -3,6 +3,8 @@
 #include <ompl/geometric/planners/rrt/RRTstar.h>
 
 #include "PlannerSettings.h"
+#include "planners/OMPLControlPlanner.hpp"
+#include "planners/OMPLPlanner.hpp"
 
 namespace ob = ompl::base;
 namespace og = ompl::geometric;
@@ -14,8 +16,31 @@ class PlannerConfigurator {
   template <typename PLANNER>
   static void configure(PLANNER &planner) {}
 
+  template <typename OMPL_PLANNER>
+  static void configure(OMPLPlanner<OMPL_PLANNER> &planner) {
+    configure(*planner.omplPlanner(),
+              global::settings.ompl.geometric_planner_settings.value());
+  }
+
+  template <typename OMPL_PLANNER>
+  static void configure(OMPLControlPlanner<OMPL_PLANNER> &planner) {
+    configure(*planner.omplPlanner(),
+              global::settings.ompl.control_planner_settings.value());
+  }
+
   static void configure(og::RRTstar &planner) {
     planner.setGoalBias(global::settings.ompl.rrt_star.goal_bias);
     planner.setRange(global::settings.ompl.rrt_star.max_distance);
+  }
+
+ private:
+  static void configure(ob::Planner &planner, const nlohmann::json &settings) {
+    const auto name = planner.getName();
+    auto params = planner.params();
+    if (settings.contains(name)) {
+      for (auto &[key, value] : settings[name].items()) {
+        params.setParam(key, value);
+      }
+    }
   }
 };

--- a/base/PlannerConfigurator.hpp
+++ b/base/PlannerConfigurator.hpp
@@ -28,11 +28,6 @@ class PlannerConfigurator {
               global::settings.ompl.control_planner_settings.value());
   }
 
-  static void configure(og::RRTstar &planner) {
-    planner.setGoalBias(global::settings.ompl.rrt_star.goal_bias);
-    planner.setRange(global::settings.ompl.rrt_star.max_distance);
-  }
-
  private:
   static void configure(ob::Planner &planner, const nlohmann::json &settings) {
     const auto name = planner.getName();

--- a/base/PlannerConfigurator.hpp
+++ b/base/PlannerConfigurator.hpp
@@ -32,9 +32,9 @@ class PlannerConfigurator {
   static void configure(ob::Planner &planner, const nlohmann::json &settings) {
     const auto name = planner.getName();
     auto params = planner.params();
-    if (settings.contains(name)) {
-      for (auto &[key, value] : settings[name].items()) {
-        params.setParam(key, value);
+    if (settings.find(name) != settings.end()) {
+      for (auto it = settings[name].begin(); it!= settings[name].end(); ++it) {
+        params.setParam(it.key(), it.value());
       }
     }
   }

--- a/base/PlannerSettings.h
+++ b/base/PlannerSettings.h
@@ -308,6 +308,11 @@ struct GlobalSettings : public Group {
   struct OmplSettings : public Group {
     using Group::Group;
 
+    /**
+     * Custom constructor to expose planner settings and their default values.
+     */
+    OmplSettings(const char *name, Group *parent = nullptr);
+
     ompl::base::StateSpacePtr state_space{nullptr};
     ompl::control::ControlSpacePtr control_space{nullptr};
     ompl::base::SpaceInformationPtr space_info{nullptr};
@@ -342,12 +347,38 @@ struct GlobalSettings : public Group {
         "min_pathlength", "optimization_objective", this};
 
     /**
-     * Planner settings for all planners.
+     * Retrieve available parameters and defaults for geometric planners.
+     */
+    void retrieveGeometricPlannerParams();
+
+    /**
+     * Planner settings for geometric planners.
+     *
+     * Geometric and control planners are split since planner names are not
+     * unique across these two namespaces.
+     *
+     * Keys are planners names, values are key:value pairs of planner
+     * parameters.
+     */
+    Property<nlohmann::json> geometric_planner_settings{
+        {}, "geometric_planner_settings", this};
+
+    /**
+     * Retrieve available parameters and defaults for control planners.
+     */
+    void retrieveControlPlannerParams();
+
+    /**
+     * Planner settings for control planners.
+     *
+     * Geometric and control planners are split since planner names are not
+     * unique across these two namespaces.
      *
      * Keys are planners names, values are key:value pairs of planner
      * parameters. Populated with default params in constructor.
      */
-    Property<nlohmann::json> planner_settings{{}, "planner_settings", this};
+    Property<nlohmann::json> control_planner_settings{
+        {}, "control_planner_settings", this};
 
     struct RRTstarSettings : public Group {
       using Group::Group;

--- a/base/PlannerSettings.h
+++ b/base/PlannerSettings.h
@@ -380,20 +380,6 @@ struct GlobalSettings : public Group {
     Property<nlohmann::json> control_planner_settings{
         {}, "control_planner_settings", this};
 
-    struct RRTstarSettings : public Group {
-      using Group::Group;
-
-      /**
-       * Probability of selecting the goal state during the exploration.
-       */
-      Property<double> goal_bias{0.05, "goal_bias", this};
-
-      /**
-       * Maximum length of a motion to be added to the tree.
-       */
-      Property<double> max_distance{0., "max_distance", this};
-    } rrt_star{"rrt_star", this};
-
     /**
      * Sets the OMPL sampler based on the state space (steering function) and
      * selected sampler.

--- a/base/PlannerSettings.h
+++ b/base/PlannerSettings.h
@@ -341,6 +341,14 @@ struct GlobalSettings : public Group {
     Property<std::string> optimization_objective{
         "min_pathlength", "optimization_objective", this};
 
+    /**
+     * Planner settings for all planners.
+     *
+     * Keys are planners names, values are key:value pairs of planner
+     * parameters. Populated with default params in constructor.
+     */
+    Property<nlohmann::json> planner_settings{{}, "planner_settings", this};
+
     struct RRTstarSettings : public Group {
       using Group::Group;
 

--- a/fp_models/kinematic_car/kinematic_car.hpp
+++ b/fp_models/kinematic_car/kinematic_car.hpp
@@ -12,7 +12,7 @@ namespace ob = ompl::base;
 namespace KinematicCar {
 // as in
 // https://ompl.kavrakilab.org/RigidBodyPlanningWithODESolverAndControls_8cpp_source.html
-void kinematicCarODE(const oc::ODESolver::StateType& q,
+inline void kinematicCarODE(const oc::ODESolver::StateType& q,
                      const oc::Control* control,
                      oc::ODESolver::StateType& qdot) {
   global::settings.ompl.steering_timer.resume();
@@ -29,7 +29,7 @@ void kinematicCarODE(const oc::ODESolver::StateType& q,
 
 // as in
 // https://ompl.kavrakilab.org/RigidBodyPlanningWithODESolverAndControls_8cpp_source.html
-void kinematicCarPostIntegration(const ob::State* /*state*/,
+inline void kinematicCarPostIntegration(const ob::State* /*state*/,
                                  const oc::Control* /*control*/,
                                  const double /*duration*/, ob::State* result) {
   // Normalize orientation between 0 and 2*pi
@@ -38,7 +38,7 @@ void kinematicCarPostIntegration(const ob::State* /*state*/,
                         ->as<ob::SO2StateSpace::StateType>(1));
 }
 
-void propagate(const oc::SpaceInformation* si, const ob::State* state,
+inline void propagate(const oc::SpaceInformation* si, const ob::State* state,
                const oc::Control* control, const double duration,
                ob::State* result) {
   global::settings.ompl.steering_timer.resume();

--- a/fp_models/kinematic_single_track/kinematic_single_track.hpp
+++ b/fp_models/kinematic_single_track/kinematic_single_track.hpp
@@ -12,7 +12,7 @@ namespace ob = ompl::base;
 namespace kinematicSingleTrack {
 // as in
 // https://gitlab.lrz.de/tum-cps/commonroad-vehicle-models/blob/master/vehicleModels_commonRoad.pdf
-void kinematicSingleTrackODE(const oc::ODESolver::StateType& q,
+inline void kinematicSingleTrackODE(const oc::ODESolver::StateType& q,
                              const oc::Control* control,
                              oc::ODESolver::StateType& qdot) {
   global::settings.ompl.steering_timer.resume();
@@ -33,7 +33,7 @@ void kinematicSingleTrackODE(const oc::ODESolver::StateType& q,
 
 // as in
 // https://gitlab.lrz.de/tum-cps/commonroad-vehicle-models/blob/master/vehicleModels_commonRoad.pdf
-void kinematicSingleTrackPostIntegration(const ob::State* state,
+inline void kinematicSingleTrackPostIntegration(const ob::State* state,
                                          const oc::Control* /*control*/,
                                          const double /*duration*/,
                                          ob::State* result) {
@@ -44,7 +44,7 @@ void kinematicSingleTrackPostIntegration(const ob::State* state,
   SO2.enforceBounds(se2state->as<ob::SO2StateSpace::StateType>(1));
 }
 
-void propagate(const oc::SpaceInformation* si, const ob::State* state,
+inline void propagate(const oc::SpaceInformation* si, const ob::State* state,
                const oc::Control* control, const double duration,
                ob::State* result) {
   global::settings.ompl.steering_timer.resume();


### PR DESCRIPTION
This exposes OMPL's parameter interface for both geometric and control planners.

When creating the settings object, each planner is created once to retrieve their parameters (and their defaults). These can then be overwritten in the json config, and will be applied by the `PlannerConfigurator`. Since all parameters are part of the settings they are automatically logged too.

I removed the previous RRT* config, since both parameters are supported by the OMPL interface (in general it seems quite well supported) and so this code and the params were now redundant.

Closes #20.