### PR TITLE
Fix/default parameters

### DIFF
--- a/base/PathStatistics.hpp
+++ b/base/PathStatistics.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <params.hpp>
 #include <string>
 #include <utility>
@@ -40,6 +41,7 @@ struct PathStatistics : public Group {
   Property<double> max_clearing_distance{
       std::numeric_limits<double>::quiet_NaN(), "max_clearing_distance", this};
   Property<std::string> planner{"UNKNOWN", "planner", this};
+  Property<nlohmann::json> planner_settings{{}, "planner_settings", this};
   Property<std::vector<Point>> cusps{{}, "cusps", this};
   Property<std::vector<Point>> collisions{{}, "collisions", this};
 

--- a/base/PlannerConfigurator.hpp
+++ b/base/PlannerConfigurator.hpp
@@ -36,8 +36,6 @@ class PlannerConfigurator {
       for (auto it = settings[name].begin(); it != settings[name].end(); ++it) {
         if (it.value() != "") {
           params.setParam(it.key(), it.value());
-          std::cout << "Setting param " << it.key() << " to " << it.value()
-                    << std::endl;
         }
       }
     } else {

--- a/base/PlannerConfigurator.hpp
+++ b/base/PlannerConfigurator.hpp
@@ -33,9 +33,16 @@ class PlannerConfigurator {
     const auto name = planner.getName();
     auto params = planner.params();
     if (settings.find(name) != settings.end()) {
-      for (auto it = settings[name].begin(); it!= settings[name].end(); ++it) {
-        params.setParam(it.key(), it.value());
+      for (auto it = settings[name].begin(); it != settings[name].end(); ++it) {
+        if (it.value() != "") {
+          params.setParam(it.key(), it.value());
+          std::cout << "Setting param " << it.key() << " to " << it.value()
+                    << std::endl;
+        }
       }
+    } else {
+      std::cout << "Warning: Could not find planner name in settings json: "
+                << name << std::endl;
     }
   }
 };

--- a/base/src/PlannerSettings.cpp
+++ b/base/src/PlannerSettings.cpp
@@ -362,8 +362,7 @@ void PlannerSettings::GlobalSettings::OmplSettings::retrieveGeometricPlannerPara
   for (auto planner : planners) {
     const auto &param_map = planner->params().getParams();
     for (const auto &[key, value_ptr] : param_map) {
-      geometric_planner_settings.value()[planner->getName()][key] =
-          value_ptr->getValue();
+      geometric_planner_settings.value()[planner->getName()][key] = "";
     }
   }
   ompl::msg::setLogLevel(ompl::msg::LOG_INFO);
@@ -390,8 +389,7 @@ void PlannerSettings::GlobalSettings::OmplSettings::retrieveControlPlannerParams
   for (auto planner : planners) {
     const auto &param_map = planner->params().getParams();
     for (const auto &[key, value_ptr] : param_map) {
-      control_planner_settings.value()[planner->getName()][key] =
-          value_ptr->getValue();
+      control_planner_settings.value()[planner->getName()][key] = "";
     }
   }
   ompl::msg::setLogLevel(ompl::msg::LOG_INFO);

--- a/bin/benchmark_template.json
+++ b/bin/benchmark_template.json
@@ -127,12 +127,176 @@
     "max_path_length": 10000.0,
     "max_planning_time": 15.0,
     "ompl": {
-      "cost_threshold": 100.0,
-      "optimization_objective": "min_pathlength",
-      "rrt_star": {
-        "goal_bias": 0.05,
-        "max_distance": 0.0
+      "control_planner_settings": {
+        "EST": {
+          "goal_bias": "",
+          "range": ""
+        },
+        "KPIECE1": {
+          "bad_score_factor": "",
+          "border_fraction": "",
+          "goal_bias": "",
+          "good_score_factor": "",
+          "max_close_samples": ""
+        },
+        "PDST": {
+          "goal_bias": ""
+        },
+        "RRT": {
+          "goal_bias": "",
+          "intermediate_states": ""
+        },
+        "SST": {
+          "goal_bias": "",
+          "pruning_radius": "",
+          "selection_radius": ""
+        }
       },
+      "cost_threshold": 100.0,
+      "geometric_planner_settings": {
+        "BFMT": {
+          "balanced": "",
+          "cache_cc": "",
+          "extended_fmt": "",
+          "heuristics": "",
+          "nearest_k": "",
+          "num_samples": "",
+          "optimality": "",
+          "radius_multiplier": ""
+        },
+        "BITstar": {
+          "delay_rewiring_to_first_solution": "",
+          "drop_unconnected_samples_on_prune": "",
+          "find_approximate_solutions": "",
+          "prune_threshold_as_fractional_cost_change": "",
+          "rewire_factor": "",
+          "samples_per_batch": "",
+          "stop_on_each_solution_improvement": "",
+          "use_graph_pruning": "",
+          "use_just_in_time_sampling": "",
+          "use_k_nearest": "",
+          "use_strict_queue_ordering": ""
+        },
+        "CForest": {
+          "focus_search": "",
+          "num_threads": ""
+        },
+        "EST": {
+          "goal_bias": "",
+          "range": ""
+        },
+        "FMT": {
+          "cache_cc": "",
+          "extended_fmt": "",
+          "heuristics": "",
+          "nearest_k": "",
+          "num_samples": "",
+          "radius_multiplier": ""
+        },
+        "InformedRRTstar": {
+          "delay_collision_checking": "",
+          "goal_bias": "",
+          "number_sampling_attempts": "",
+          "ordered_sampling": "",
+          "ordering_batch_size": "",
+          "prune_threshold": "",
+          "range": "",
+          "rewire_factor": "",
+          "use_k_nearest": ""
+        },
+        "KPIECE1": {
+          "border_fraction": "",
+          "failed_expansion_score_factor": "",
+          "goal_bias": "",
+          "min_valid_path_fraction": "",
+          "range": ""
+        },
+        "PDST": {
+          "goal_bias": ""
+        },
+        "PRM": {
+          "max_nearest_neighbors": ""
+        },
+        "RRT": {
+          "goal_bias": "",
+          "intermediate_states": "",
+          "range": ""
+        },
+        "RRT#": {
+          "goal_bias": "",
+          "informed_sampling": "",
+          "number_sampling_attempts": "",
+          "range": "",
+          "rejection_variant": "",
+          "rejection_variant_alpha": "",
+          "rewire_factor": "",
+          "sample_rejection": "",
+          "update_children": "",
+          "use_k_nearest": ""
+        },
+        "RRTstar": {
+          "delay_collision_checking": "",
+          "focus_search": "",
+          "goal_bias": "",
+          "informed_sampling": "",
+          "new_state_rejection": "",
+          "number_sampling_attempts": "",
+          "ordered_sampling": "",
+          "ordering_batch_size": "",
+          "prune_threshold": "",
+          "pruned_measure": "",
+          "range": "",
+          "rewire_factor": "",
+          "sample_rejection": "",
+          "tree_pruning": "",
+          "use_admissible_heuristic": "",
+          "use_k_nearest": ""
+        },
+        "SBL": {
+          "range": ""
+        },
+        "SORRTstar": {
+          "delay_collision_checking": "",
+          "goal_bias": "",
+          "number_sampling_attempts": "",
+          "ordered_sampling": "",
+          "ordering_batch_size": "",
+          "prune_threshold": "",
+          "range": "",
+          "rewire_factor": "",
+          "use_k_nearest": ""
+        },
+        "SPARS": {
+          "dense_delta_fraction": "",
+          "max_failures": "",
+          "sparse_delta_fraction": "",
+          "stretch_factor": ""
+        },
+        "SPARStwo": {
+          "dense_delta_fraction": "",
+          "max_failures": "",
+          "sparse_delta_fraction": "",
+          "stretch_factor": ""
+        },
+        "SST": {
+          "goal_bias": "",
+          "pruning_radius": "",
+          "range": "",
+          "selection_radius": ""
+        },
+        "STRIDE": {
+          "degree": "",
+          "estimated_dimension": "",
+          "goal_bias": "",
+          "max_degree": "",
+          "max_pts_per_leaf": "",
+          "min_degree": "",
+          "min_valid_path_fraction": "",
+          "range": "",
+          "use_projected_distance": ""
+        }
+      },
+      "optimization_objective": "min_pathlength",
       "sampler": "iid",
       "seed": 1,
       "state_equality_tolerance": 0.0001

--- a/planners/AbstractPlanner.h
+++ b/planners/AbstractPlanner.h
@@ -20,6 +20,8 @@
 
 #include <ompl/control/ODESolver.h>
 
+#include <nlohmann/json.hpp>
+
 namespace ob = ompl::base;
 namespace og = ompl::geometric;
 namespace oc = ompl::control;
@@ -116,4 +118,5 @@ class AbstractPlanner {
 
  public:
   virtual ob::Planner *omplPlanner() { return nullptr; }
+  virtual nlohmann::json getSettings() const { return {};}
 };

--- a/planners/OMPLControlPlanner.hpp
+++ b/planners/OMPLControlPlanner.hpp
@@ -143,6 +143,15 @@ class OMPLControlPlanner : public AbstractPlanner {
 
   ob::Planner *omplPlanner() override { return _omplPlanner.get(); }
 
+  virtual nlohmann::json getSettings() const override {
+    nlohmann::json settings;
+    const auto &param_map = _omplPlanner->params().getParams();
+    for (const auto &[key, value_ptr] : param_map) {
+      settings[key] = value_ptr->getValue();;
+    }
+    return settings;
+  }
+
   ob::PlannerTerminationCondition approxSolnPlannerTerminationCondition(
       const ompl::base::ProblemDefinitionPtr &pdef) {
     return ob::PlannerTerminationCondition(

--- a/planners/OMPLPlanner.hpp
+++ b/planners/OMPLPlanner.hpp
@@ -118,6 +118,15 @@ class OMPLPlanner : public AbstractPlanner {
 
   ob::Planner *omplPlanner() override { return _omplPlanner.get(); }
 
+  virtual nlohmann::json getSettings() const override {
+    nlohmann::json settings;
+    const auto &param_map = _omplPlanner->params().getParams();
+    for (const auto &[key, value_ptr] : param_map) {
+      settings[key] = value_ptr->getValue();
+    }
+    return settings;
+  }
+
  private:
   ob::PlannerPtr _omplPlanner;
   og::PathGeometric _solution{global::settings.ompl.space_info};

--- a/utils/PathEvaluation.hpp
+++ b/utils/PathEvaluation.hpp
@@ -29,6 +29,7 @@ struct PathEvaluation {
     j["stats"] = nlohmann::json(empty_stats)["stats"];
     j["trajectory"] = {};
     j["intermediary_solutions"] = {};
+    j["params"] = {};
   }
 
  public:
@@ -58,6 +59,7 @@ struct PathEvaluation {
     stats.collision_time = global::settings.environment->elapsedCollisionTime();
     stats.steering_time = global::settings.ompl.steering_timer.elapsed();
     stats.planner = planner->name();
+    stats.planner_settings = planner->getSettings();
     if (path.getStateCount() < 2) {
       stats.path_found = false;
       stats.exact_goal_path = false;
@@ -107,6 +109,7 @@ struct PathEvaluation {
     stats.collision_time = global::settings.environment->elapsedCollisionTime();
     stats.steering_time = global::settings.ompl.steering_timer.elapsed();
     stats.planner = planner->name();
+    stats.planner_settings = planner->getSettings();
     if (path.getStateCount() < 2) {
       stats.path_found = false;
       stats.exact_goal_path = false;


### PR DESCRIPTION
I found some issues with the OMPL planner parameters. Namely, the default parameters were retrieved before calling setup. But some planners change the default settings when calling setup, so that the default is now different from before (for example OMPL has a default k of 0 now, which doesn't work of course, after setup the default is set to 10, if not set before). I tried calling setup to retrieve the same parameters, but the defaults are environment dependent. So it seems difficult to provide a default.

As a fix I removed the default parameters in the template file and added only add an empty string "", which indicates "don't touch this parameter", Also I log the final parameters to stats.planner_settings now (so that we know what is set by OMPL if nothing is specified).